### PR TITLE
Add conditional logic for non sandbox deployment

### DIFF
--- a/nubis/bin/consul_inputs.sh
+++ b/nubis/bin/consul_inputs.sh
@@ -55,7 +55,7 @@ update-consul () {
     curl -s -X PUT -d $wgDBuser $CONSUL/wgDBuser
 }
 
-get_and_update () {
+get-and-update () {
     # If we do not get an I/O file then put on in temp
     if [ ! -f ${IO_FILE:-0} ]; then
         AUTOGEN_IO=1
@@ -92,6 +92,7 @@ while [ "$1" != "" ]; do
             echo -en "$0\n\n"
             echo -en "Usage: $0 [options] command\n\n"
             echo -en "Commands:\n"
+            echo -en "  get-and-update              Run get-outputs followed by update-consul\n"
             echo -en "  get-outputs                 Get defined outputs\n"
             echo -en "  update-consul               Put values into Consul\n"
             echo -en "  get-route53-nameservers     Get the list of Route53 nameservers\n\n"
@@ -121,9 +122,9 @@ while [ "$1" != "" ]; do
             get-route53-nameservers
         ;;
 
-        io | get_and_update )
+        io | get-and-update )
             # Get the outputs from AWS and put them in Consul
-            get_and_update
+            get-and-update
         ;;
     esac
     shift

--- a/nubis/cloudformation/main.json
+++ b/nubis/cloudformation/main.json
@@ -78,6 +78,11 @@
     }
   },
 
+  "Conditions" : {
+    "CreateSandboxResources" : {"Fn::Equals" : [{"Ref" : "EnvType"}, "sandbox"]},
+    "CreateAutomationResources" : {"Fn::Not" : [{ "Fn::Equals" : [{"Ref" : "EnvType"}, "sandbox"]} ]}
+  },
+
   "Resources": {
     "EC2SecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
@@ -272,27 +277,49 @@
     },
     "HostedZone": {
       "Type" : "AWS::Route53::HostedZone",
+      "Condition" : "CreateSandboxResources",
       "Properties" : {
         "Name" : {
             "Fn::Join" : [ ".", [
-               { "Ref": "ProjectName" }, { "Ref" : "BaseZone" }
+               { "Ref": "ProjectName" }, { "Ref" : "EnvType" }, { "Ref" : "BaseZone" }
             ] ]
          }
       }
     },
     "WWWRecord" : {
       "Type" : "AWS::Route53::RecordSet",
+      "Condition" : "CreateSandboxResources",
       "DependsOn" : "HostedZone",
       "Properties" : 
       {
         "HostedZoneName" : {
             "Fn::Join" : [ "", [
-               { "Ref": "ProjectName" }, ".", { "Ref" : "BaseZone" }, "."
+               { "Ref": "ProjectName" }, ".", { "Ref" : "EnvType" }, ".", { "Ref" : "BaseZone" }, "."
             ] ]
          },
         "Name" :  {
             "Fn::Join" : [ "", [
-               "www", ".", { "Ref": "ProjectName" }, ".", { "Ref" : "BaseZone" }, "."
+               "www", ".", { "Ref": "ProjectName" }, ".", { "Ref" : "EnvType" }, ".", { "Ref" : "BaseZone" }, "."
+            ] ]
+         },
+        "Type" : "CNAME",
+        "TTL" : "300",
+        "ResourceRecords" : [ { "Fn::GetAtt" : [ "ELB", "DNSName" ] } ]
+      }
+    },
+    "WWWRecord" : {
+      "Type" : "AWS::Route53::RecordSet",
+      "Condition" : "CreateAutomationResources",
+      "Properties" : 
+      {
+        "HostedZoneName" : {
+            "Fn::Join" : [ "", [
+               { "Ref": "ProjectName" }, ".", { "Ref" : "EnvType" }, ".", { "Ref" : "BaseZone" }, "."
+            ] ]
+         },
+        "Name" :  {
+            "Fn::Join" : [ "", [
+               "www", ".", { "Ref": "ProjectName" }, ".", { "Ref" : "EnvType" }, ".", { "Ref" : "BaseZone" }, "."
             ] ]
          },
         "Type" : "CNAME",


### PR DESCRIPTION
When NOT in the sandbox we do not create the hostedzone, that is part of the project onboarding process. Due to the need for a declaired dependancy between the hostedzone and the records there is aneed to declair the records twice, once when creating the hostedzone and once when deploying into an automated environment.
