### PR TITLE
Parameterizing subnets

### DIFF
--- a/nubis/cloudformation/README.md
+++ b/nubis/cloudformation/README.md
@@ -21,5 +21,5 @@ aws cloudformation delete-stack --stack-name nubis-mediawiki
 
 After creating or updating a stack you might need to update Consul. Run this command to take any (properly described) Cloudformation outputs and insert or update them in Consul:
 ```bash
-bash nubis/bin/consul_inputs.sh --settings nubis/cloudformation/parameterss.json get-and-update
+bash nubis/bin/consul_inputs.sh --settings nubis/cloudformation/parameters.json get-and-update
 ```

--- a/nubis/cloudformation/main.json
+++ b/nubis/cloudformation/main.json
@@ -5,7 +5,7 @@
       "Description": "Name of this project",
       "Type": "String"
     },
-    "EnvType": {
+    "Environment": {
       "Description": "Environment we are deploying into",
       "Default": "sandbox",
       "Type": "String",
@@ -91,7 +91,7 @@
     "CreateSandboxResources": {
       "Fn::Equals": [
         {
-          "Ref": "EnvType"
+          "Ref": "Environment"
         },
         "sandbox"
       ]
@@ -101,7 +101,7 @@
         {
           "Fn::Equals": [
             {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             },
             "sandbox"
           ]
@@ -141,7 +141,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             }
           },
           {
@@ -208,7 +208,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             }
           },
           {
@@ -241,7 +241,7 @@
           "Fn::FindInMap": [
             "InstanceTypeMap",
             {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             },
             "InstanceType"
           ]
@@ -272,7 +272,7 @@
                     [
                       "NUBIS_ENVIRONMENT='",
                       {
-                        "Ref": "EnvType"
+                        "Ref": "Environment"
                       },
                       "'"
                     ]
@@ -443,7 +443,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             },
             "PropagateAtLaunch": "true"
           },
@@ -531,7 +531,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             }
           },
           {
@@ -585,7 +585,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             }
           },
           {
@@ -694,7 +694,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             }
           },
           {
@@ -758,7 +758,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             }
           },
           {
@@ -807,7 +807,7 @@
           {
             "Key": "Environment",
             "Value": {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             }
           },
           {
@@ -837,7 +837,7 @@
                 "Ref": "ProjectName"
               },
               {
-                "Ref": "EnvType"
+                "Ref": "Environment"
               },
               {
                 "Ref": "BaseZone"
@@ -860,7 +860,7 @@
               },
               ".",
               {
-                "Ref": "EnvType"
+                "Ref": "Environment"
               },
               ".",
               {
@@ -881,7 +881,7 @@
               },
               ".",
               {
-                "Ref": "EnvType"
+                "Ref": "Environment"
               },
               ".",
               {
@@ -925,7 +925,7 @@
               "Ref": "ProjectName"
             },
             {
-              "Ref": "EnvType"
+              "Ref": "Environment"
             },
             "nubis.allizom.org"
           ]

--- a/nubis/cloudformation/main.json
+++ b/nubis/cloudformation/main.json
@@ -57,6 +57,14 @@
       "Description": "Id of the VPC",
       "Type": "String"
     },
+    "Subnets": {
+      "Description": "Coma, seperated, list, of, subnets",
+      "Type": "CommaDelimitedList"
+    },
+    "ELBSubnets": {
+      "Description": "ELBs live in their own coma, seperated, list, of, subnets",
+      "Type": "CommaDelimitedList"
+    },
     "TechnicalOwner": {
       "Description": "A valid LDAP email",
       "Type": "String"
@@ -381,9 +389,30 @@
           "Fn::GetAZs": ""
         },
         "VPCZoneIdentifier": [
-          "subnet-a9139ccc",
-          "subnet-cb3a97bc",
-          "subnet-227fbc7b"
+           {
+            "Fn::Select": [
+              "0",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "1",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "2",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          }
         ],
         "LaunchConfigurationName": {
           "Ref": "LaunchConfig"
@@ -440,9 +469,30 @@
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "Subnets": [
-          "subnet-dc139cb9",
-          "subnet-ea3a979d",
-          "subnet-3f7fbc66"
+           {
+            "Fn::Select": [
+              "0",
+              {
+                "Ref": "ELBSubnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "1",
+              {
+                "Ref": "ELBSubnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "2",
+              {
+                "Ref": "ELBSubnets"
+              }
+            ]
+          }
         ],
         "SecurityGroups": [
           {
@@ -558,9 +608,30 @@
       "Properties": {
         "Description": "ElastiCache Subnet Group",
         "SubnetIds": [
-          "subnet-a9139ccc",
-          "subnet-cb3a97bc",
-          "subnet-227fbc7b"
+           {
+            "Fn::Select": [
+              "0",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "1",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "2",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          }
         ]
       }
     },
@@ -646,9 +717,30 @@
       "Properties": {
         "DBSubnetGroupDescription": "DB Subnet Group",
         "SubnetIds": [
-          "subnet-a9139ccc",
-          "subnet-cb3a97bc",
-          "subnet-227fbc7b"
+          {
+            "Fn::Select": [
+              "0",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "1",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          },
+          {
+            "Fn::Select": [
+              "2",
+              {
+                "Ref": "Subnets"
+              }
+            ]
+          }
         ],
         "Tags": [
           {

--- a/nubis/cloudformation/parameters.json-dist
+++ b/nubis/cloudformation/parameters.json-dist
@@ -36,6 +36,14 @@
     "ParameterValue": "vpc-abcdef123"
   },
   {
+    "ParameterKey": "Subnets",
+    "ParameterValue": "subnet-123, subnet-456, subnet-789"
+  },
+  {
+    "ParameterKey": "ELBSubnets",
+    "ParameterValue": "subnet-abc, subnet-def, subnet-ghi"
+  },
+  {
     "ParameterKey": "TechnicalOwner",
     "ParameterValue": "email"
   },

--- a/nubis/cloudformation/parameters.json-dist
+++ b/nubis/cloudformation/parameters.json-dist
@@ -4,7 +4,7 @@
     "ParameterValue": "mediawiki"
   }, 
   {
-    "ParameterKey": "EnvType",
+    "ParameterKey": "Environment",
     "ParameterValue": "sandbox"
   }, 
   {


### PR DESCRIPTION
This logic is a little off putting. It iterates through the list manually as cloudformation has no way to determine the number of elements and then iterate through the list. Basically this means that we must always have three subnet ids for both the project and the ELB subnets. I _think_ this is fairly safe as there tend to be three availability zones in each region and so far we seem to be provisioning across all three, but it is still bad practice.

If someone knows of a better way I am open to suggestions.
